### PR TITLE
Don't process node js functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ class PkgPyFuncs {
   }
 
   selectAll() {
-    const functions = this.serverless.service.functions
+    const functions = _.reject(this.serverless.service.functions, { runtime: 'nodejs6.10' });
     const info = _.map(functions, (target) => {
       return {
         name: target.name,

--- a/index.js
+++ b/index.js
@@ -51,7 +51,10 @@ class PkgPyFuncs {
   }
 
   selectAll() {
-    const functions = _.reject(this.serverless.service.functions, { runtime: 'nodejs6.10' });
+    const functions = _.reject(this.serverless.service.functions, (target) => {
+      return target.runtime && !(target.runtime + '').match(/python/i);
+    });
+
     const info = _.map(functions, (target) => {
       return {
         name: target.name,


### PR DESCRIPTION
This little change skips package-python-functions if function runtime is node js 6.10